### PR TITLE
Allow SwiftUI-defined backgrounds behind PageView with .scroll style

### DIFF
--- a/Sources/BigUIPaging/Implementations/PageView/Platform/PlatformPageView+iOS.swift
+++ b/Sources/BigUIPaging/Implementations/PageView/Platform/PlatformPageView+iOS.swift
@@ -101,7 +101,8 @@ extension PlatformPageView {
         func makeViewController(_ value: SelectionValue) -> UIViewController {
             ContainerViewController(
                 value: value,
-                view: parent.content(value)
+                view: parent.content(value),
+                configuration: parent.configuration
             )
         }
         
@@ -144,11 +145,13 @@ extension PlatformPageView {
         
         let value: SelectionValue
         let content: Content
+        let configuration: PlatformPageViewConfiguration
         var hostingController: UIViewController?
         
-        init(value: SelectionValue, view: Content) {
+        init(value: SelectionValue, view: Content, configuration: PlatformPageViewConfiguration) {
             self.value = value
             self.content = view
+            self.configuration = configuration
             super.init(nibName: nil, bundle: nil)
         }
         
@@ -165,6 +168,9 @@ extension PlatformPageView {
                     .flexibleWidth,
                     .flexibleHeight
                 ]
+                if let backgroundColor = configuration.customBackgroundColor {
+                    hostingController.view.backgroundColor = backgroundColor
+                }
                 self.addChild(hostingController)
                 self.view.addSubview(hostingController.view)
                 self.hostingController = hostingController

--- a/Sources/BigUIPaging/Implementations/PageView/Platform/PlatformPageView.swift
+++ b/Sources/BigUIPaging/Implementations/PageView/Platform/PlatformPageView.swift
@@ -24,4 +24,12 @@ struct PlatformPageViewConfiguration {
     let transition: Transition
     let orientation: Axis
     let spacing: Double
+    let customBackgroundColor: UIColor?
+    
+    init(transition: Transition, orientation: Axis, spacing: Double, customBackgroundColor: UIColor? = nil) {
+        self.transition = transition
+        self.orientation = orientation
+        self.spacing = spacing
+        self.customBackgroundColor = customBackgroundColor
+    }
 }

--- a/Sources/BigUIPaging/Implementations/PageView/Styles/ScrollPageViewStyle.swift
+++ b/Sources/BigUIPaging/Implementations/PageView/Styles/ScrollPageViewStyle.swift
@@ -19,7 +19,8 @@ public struct ScrollPageViewStyle: PageViewStyle {
             options: .init(
                 transition: .scroll,
                 orientation: orientation,
-                spacing: spacing ?? 0
+                spacing: spacing ?? 0,
+                customBackgroundColor: .clear
             )
         )
         .makeBody(configuration: configuration)


### PR DESCRIPTION
With `.pageViewStyle(.scroll)` I couldn’t set a background for the overall view in SwiftUI, only for each individual page’s content. Viewing the UI hierarchy in Xcode showed the `ContentHostingController` being stuck with the default white background. This PR sets the hosting controller’s view background color to `.clear` if the style is `.scroll`, allowing any background set in SwiftUI to show through.

I did this by adding a `customBackgroundColor` property to `PlatformPageViewConfiguration`, then passing the configuration all the way to the `ContainerViewController` so it can be referenced when creating the hosting controller. I’m not sure this is the best approach architecturally, but this way allows each `PageViewStyle` to define its own background color if needed (I found that setting a clear background broke the `.book` style and was only needed for `.scroll`), and doesn’t break API compatibility as far as I can tell.